### PR TITLE
Pyramid Plunder tweaks

### DIFF
--- a/Server/src/plugin/activity/pyramidplunder/GuardMummyDialogue.java
+++ b/Server/src/plugin/activity/pyramidplunder/GuardMummyDialogue.java
@@ -7,26 +7,22 @@ import org.crandor.game.node.entity.player.Player;
 
 /**
  * Handles Guardian mummy dialogue.
- * @author Emperor
+ * @author Originally Emperor, completely redone by Ceikry.
  */
 public final class GuardMummyDialogue extends DialoguePlugin {
 
 	/**
 	 * If the player successfully caught the evil twin.
+	 * Will remain unused until the quest is implemented. (if ever)
 	 */
-	private int type;
+	//private int type;
 
-	/**
-	 * Constructs a new {@code GuardMummyDialogue} {@code Object}.
-	 */
-	public GuardMummyDialogue() {
-		super();
-	}
 
 	/**
 	 * Constructs a new {@code GuardMummyDialogue} {@code Object}.
 	 * @param player The player.
 	 */
+	public GuardMummyDialogue() {super();}
 	public GuardMummyDialogue(Player player) {
 		super(player);
 	}
@@ -39,18 +35,78 @@ public final class GuardMummyDialogue extends DialoguePlugin {
 	@Override
 	public boolean open(Object... args) {
 		npc = (NPC) args[0];
-		type = args.length == 1 ? 0 : (Integer) args[1];
+		if(args.length > 1){
+			switch((int) args[1]){
+				case 0:
+					npc("You! How did you get into this place?");
+					stage = 50;
+					break;
+				case 1:
+					player("I know what I'm doing - let's get on with it.");
+					stage = 10;
+					break;
+			}
+		} else {
+			npc("Errr");
+		}
+		/*type = args.length == 1 ? 0 : (Integer) args[1];
 		if (type == 1) {
 			player("I know what I'm doing - let's get on with it.");
 		} else {
-			System.out.println("TODO:1");
-		}
+			npc("You! How did you get in?");
+		}*/
 		return true;
 	}
 
 	@Override
 	public boolean handle(int interfaceId, int buttonId) {
-		switch (stage++) {
+		switch(stage){
+			case 10:
+				npc("Fine, I'll take you to the first room now...");
+				stage = 60;
+				break;
+			case 50:
+				player("I could ask you the same thing.");
+				stage = 51;
+				break;
+			case 51:
+				npc("Nevermind that. I suppose since you're here I can tell", "you how to play.");
+				stage = 52;
+				break;
+			case 52:
+				npc("In each room there are urns, a chest, and a sarcophagus.");
+				stage = 53;
+				break;
+			case 53:
+				npc("The urns contain artifacts based on the room that you are","currently in. The chest contains valuable artifacts but is","sometimes trapped. The sarcophagus has one of my","brothers in it. And lots of artifacts.");
+				stage = 54;
+				break;
+			case 54:
+				player("Anything else I should know?");
+				stage = 55;
+				break;
+			case 55:
+				npc("Yes, each room requires more thieving knowledge than the"," last. And be careful not to die.");
+				stage = 56;
+				break;
+			case 56:
+				player("Oh, yes, dying. Not good. Well I suppose that covers it?");
+				stage = 57;
+				break;
+			case 57:
+				npc("Yep.");
+				stage = 58;
+				break;
+			case 58:
+				end();
+				break;
+			case 60:
+				end();
+				ActivityManager.start(player, "Pyramid plunder", false);
+				break;
+
+		}
+		/*switch (stage++) {
 		case 0:
 			if (type == 1) {
 				npc("Fine, I'll take you to the first room now...");
@@ -66,7 +122,7 @@ public final class GuardMummyDialogue extends DialoguePlugin {
 				System.out.println("TODO:3");
 			}
 			return true;
-		}
+		}*/
 		return false;
 	}
 

--- a/Server/src/plugin/activity/pyramidplunder/PyramidPlunderMummyNPC.java
+++ b/Server/src/plugin/activity/pyramidplunder/PyramidPlunderMummyNPC.java
@@ -1,0 +1,53 @@
+package plugin.activity.pyramidplunder;
+import org.crandor.game.node.entity.Entity;
+import org.crandor.game.node.entity.player.Player;
+import org.crandor.game.world.map.Location;
+import org.crandor.tools.RandomFunction;
+
+/**
+ * Handles the mummy NPC in pyramid plunder
+ * @author ceik
+ */
+public final class PyramidPlunderMummyNPC extends PyramidPlunderNPC {
+
+    /**
+     * The swarm id.
+     */
+    private static final int[] IDS = new int[] { 1958 };
+
+    public PyramidPlunderMummyNPC(int id, Location location, Player player) {
+        super(id, location, player);
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        setRespawn(false);
+        getProperties().getCombatPulse().attack(player);
+        sendChat("How dare you disturb my rest!");
+    }
+
+    @Override
+    public void handleTickActions() {
+        super.handleTickActions();
+        if (!getProperties().getCombatPulse().isAttacking()) {
+            getProperties().getCombatPulse().attack(player);
+        }
+        if (getProperties().getCombatPulse().isAttacking()) {
+            if (RandomFunction.random(40) < 2) {
+                sendChat("Leave this place!");
+            }
+        }
+    }
+
+    @Override
+    public boolean isIgnoreMultiBoundaries(Entity victim) {
+        return victim == player;
+    }
+
+    @Override
+    public int[] getIds() {
+        return IDS;
+    }
+
+}

--- a/Server/src/plugin/activity/pyramidplunder/PyramidPlunderNPC.java
+++ b/Server/src/plugin/activity/pyramidplunder/PyramidPlunderNPC.java
@@ -1,0 +1,188 @@
+package plugin.activity.pyramidplunder;
+
+import org.crandor.game.interaction.MovementPulse;
+import org.crandor.game.node.entity.Entity;
+import org.crandor.game.node.entity.combat.CombatStyle;
+import org.crandor.game.node.entity.npc.AbstractNPC;
+import org.crandor.game.node.entity.player.Player;
+import org.crandor.game.world.GameWorld;
+import org.crandor.game.world.map.Location;
+import org.crandor.game.world.map.RegionManager;
+import org.crandor.game.world.map.path.Pathfinder;
+import org.crandor.plugin.Plugin;
+
+/**
+ * Handles a Pyramid Plunder enemy, adapted from AntiMacroNPC.java by ceikry
+ * @author Vexia
+ */
+public abstract class PyramidPlunderNPC extends AbstractNPC {
+
+    /**
+     * The player.
+     */
+    protected final Player player;
+
+    /**
+     * The quotes the npc will say(null if none)
+     */
+    private String[] quotes;
+
+    /**
+     * The counter representing speech cycles.
+     */
+    private int count;
+
+    /**
+     * The time until the next speech.
+     */
+    private int nextSpeech;
+
+    /**
+     * If the players time is up.
+     */
+    protected boolean timeUp;
+
+    /**
+     * The end time.
+     */
+    private int endTime;
+
+    /**
+     * Constructs a new {@code AntiMacroNPC} {@code Object}.
+     * @param id the id.
+     * @param location the location.
+     * @param player the player.
+     */
+    public PyramidPlunderNPC(int id, Location location, Player player) {
+        super(id, location);
+        this.player = player;
+        this.quotes = quotes;
+        this.endTime = (int) (GameWorld.getTicks() + (1000 / 0.6));
+    }
+
+    @Override
+    public void init() {
+        location = RegionManager.getSpawnLocation(player, this);
+        if (location == null) {
+            clear();
+            return;
+        }
+        super.init();
+        startFollowing();
+    }
+
+    @Override
+    public void handleTickActions() {
+        if (GameWorld.getTicks() > endTime) {
+            clear();
+        }
+        if (!getLocks().isMovementLocked()) {
+            if (dialoguePlayer == null || !dialoguePlayer.isActive() || !dialoguePlayer.getInterfaceManager().hasChatbox()) {
+                dialoguePlayer = null;
+            }
+        }
+        if (!player.isActive() || !getLocation().withinDistance(player.getLocation(), 10)) {
+            handlePlayerLeave();
+        }
+        if (!getPulseManager().hasPulseRunning()) {
+            startFollowing();
+        }
+        if (quotes != null) {
+            if (nextSpeech < GameWorld.getTicks() && this.getDialoguePlayer() == null && !this.getLocks().isMovementLocked()) {
+                if (count > quotes.length - 1) {
+                    return;
+                }
+                nextSpeech = (int) (GameWorld.getTicks() + (20 / 0.5));
+                if (++count >= quotes.length) {
+                    setTimeUp(true);
+                    handleTimeUp();
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Called when the player is gone.
+     */
+    public void handlePlayerLeave() {
+        clear();
+    }
+
+    /**
+     * Called when the quotes are finished.
+     */
+    public void handleTimeUp() {
+    }
+
+    @Override
+    public boolean isAttackable(Entity entity, CombatStyle style) {
+        if (entity instanceof Player && entity != player) {
+            ((Player) entity).getPacketDispatch().sendMessage("It's not after you.");
+            return false;
+        }
+        return super.isAttackable(entity, style);
+    }
+
+    @Override
+    public void onRegionInactivity() {
+        super.onRegionInactivity();
+        clear();
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+    }
+
+    @Override
+    public AbstractNPC construct(int id, Location location, Object... objects) {
+        return null;
+    }
+
+
+
+    /**
+     * Starts following the player.
+     */
+    public void startFollowing() {
+        getPulseManager().run(new MovementPulse(this, player, Pathfinder.DUMB) {
+            @Override
+            public boolean pulse() {
+                return false;
+            }
+        }, "movement");
+        face(player);
+    }
+
+    @Override
+    public Plugin<Object> newInstance(Object arg) throws Throwable {
+        return super.newInstance(arg);
+    }
+
+    /**
+     * Gets the player.
+     * @return The player.
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+
+    /**
+     * Gets the timeUp.
+     * @return The timeUp.
+     */
+    public boolean isTimeUp() {
+        return timeUp;
+    }
+
+    /**
+     * Sets the timeUp.
+     * @param timeUp The timeUp to set.
+     */
+    public void setTimeUp(boolean timeUp) {
+        this.timeUp = timeUp;
+    }
+
+}

--- a/Server/src/plugin/activity/pyramidplunder/PyramidPlunderSwarmNPC.java
+++ b/Server/src/plugin/activity/pyramidplunder/PyramidPlunderSwarmNPC.java
@@ -1,0 +1,53 @@
+package plugin.activity.pyramidplunder;
+import org.crandor.game.node.entity.Entity;
+import org.crandor.game.node.entity.player.Player;
+import org.crandor.game.world.map.Location;
+import org.crandor.tools.RandomFunction;
+
+/**
+ * Handles the swarm NPC in pyramid plunder
+ * @author ceik
+ */
+public final class PyramidPlunderSwarmNPC extends PyramidPlunderNPC {
+
+    /**
+     * The swarm id.
+     */
+    private static final int[] IDS = new int[] { 2001 };
+
+    public PyramidPlunderSwarmNPC(int id, Location location, Player player) {
+        super(id, location, player);
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        setRespawn(false);
+        getProperties().getCombatPulse().attack(player);
+        sendChat("bzzzzz");
+    }
+
+    @Override
+    public void handleTickActions() {
+        super.handleTickActions();
+        if (!getProperties().getCombatPulse().isAttacking()) {
+            getProperties().getCombatPulse().attack(player);
+        }
+        if (getProperties().getCombatPulse().isAttacking()) {
+            if (RandomFunction.random(40) < 2) {
+                sendChat("bzzzzz");
+            }
+        }
+    }
+
+    @Override
+    public boolean isIgnoreMultiBoundaries(Entity victim) {
+        return victim == player;
+    }
+
+    @Override
+    public int[] getIds() {
+        return IDS;
+    }
+
+}

--- a/Server/src/plugin/dialogue/SimonTempleton.java
+++ b/Server/src/plugin/dialogue/SimonTempleton.java
@@ -102,6 +102,7 @@ public final class SimonTempleton extends DialoguePlugin{
             case 20:
                 switch(buttonId){
                     case 1:
+                        end();
                         for(int j = 0; j < 28; j++){
                             switch(player.getInventory().getId(j)){
                                 case 9032:
@@ -121,6 +122,7 @@ public final class SimonTempleton extends DialoguePlugin{
                         stage = 999;
                         break;
                     case 2:
+                        end();
                         for(int j = 0; j < 28; j++){
                             switch(player.getInventory().getId(j)){
                                 case 9042:
@@ -140,6 +142,7 @@ public final class SimonTempleton extends DialoguePlugin{
                         stage = 999;
                         break;
                     case 3:
+                        end();
                         for(int j = 0; j < 28; j++){
                             switch(player.getInventory().getId(j)){
                                 case 9040:
@@ -159,6 +162,7 @@ public final class SimonTempleton extends DialoguePlugin{
                         stage = 999;
                         break;
                     case 4:
+                        end();
                         for(int j = 0; j < 28; j++){
                             switch(player.getInventory().getId(j)){
                                 case 9040:
@@ -202,6 +206,7 @@ public final class SimonTempleton extends DialoguePlugin{
                         stage = 999;
                         break;
                 }
+                break;
             case 30:
                 player("What! This is a genuine pharaoh's scepter - made out of"," solid gold and finely jewelled with precious gems"," by the finest craftsmen in the area.");
                 stage = 31;


### PR DESCRIPTION
* The NPCs in Pyramid Plunder now function more like random event NPCs like the Tree Spirit, in that they can only be attacked by the player who spawned them and automatically disappear when the player leaves the area. It also allows for some other neat things like overhead dialogue from the NPCs.
* You now get a message in your chatbox when you get a sceptre
* If your inventory is full when you roll a sceptre, it is sent to your bank.
* Room number and required level are now printed to chat when entering a new room.
* Guardian Mummy now has dialogue when you left click him
* There's now a chance to get pushed back/denied entry when you try to enter the guardian room (same as OSRS and RS3)
* Fixed a minor bug in Simon's dialogue