### PR TITLE
Pyramid Plunder tweaks v2: Electric boogaloo

### DIFF
--- a/Server/src/org/crandor/game/node/entity/player/Player.java
+++ b/Server/src/org/crandor/game/node/entity/player/Player.java
@@ -77,6 +77,7 @@ import org.crandor.net.packet.out.SkillLevel;
 import org.crandor.net.packet.out.UpdateSceneGraph;
 import org.crandor.plugin.Plugin;
 import org.crandor.tools.StringUtils;
+import plugin.activity.pyramidplunder.PlunderObjectManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -192,6 +193,11 @@ public class Player extends Entity {
 	 * The familiar manager.
 	 */
 	private final FamiliarManager familiarManager = new FamiliarManager(this);
+
+	/**
+	 * Pyramid Plunder Object Manager
+	 */
+	private final PlunderObjectManager plunderObjectManager = new PlunderObjectManager(this);
 
 	/**
 	 * The config manager.
@@ -1236,6 +1242,8 @@ public class Player extends Entity {
 	public IronmanManager getIronmanManager() {
 		return ironmanManager;
 	}
+
+	public PlunderObjectManager getPlunderObjectManager() {return plunderObjectManager;}
 
 	/**
 	 * Gets the emoteManager.

--- a/Server/src/plugin/activity/pyramidplunder/PlunderObject.java
+++ b/Server/src/plugin/activity/pyramidplunder/PlunderObject.java
@@ -1,0 +1,38 @@
+package plugin.activity.pyramidplunder;
+
+import org.crandor.game.node.entity.player.Player;
+import org.crandor.game.node.object.GameObject;
+import org.crandor.game.world.map.Location;
+
+/**
+ * Handles object instances for pyramid plunder
+ * @author ceik
+ */
+
+public class PlunderObject extends GameObject {
+    public boolean playerOpened;
+    private transient Player player;
+    private int thisId;
+
+
+    public PlunderObject(int id, Location location, Player player) {
+        super(id, location);
+        this.player = player;
+    }
+    public PlunderObject(){
+        /**
+         * Empty.
+         */
+    }
+
+
+    public boolean isOpenedBy(Player player){
+        try {
+            //manager.loadList("plunder.tmp");
+            PlunderObjectManager manager = player.getPlunderObjectManager();
+            return manager.ObjectList.get(manager.ObjectList.indexOf(this)).playerOpened;
+        } catch (Exception e){
+            return false;
+        }
+    }
+}

--- a/Server/src/plugin/activity/pyramidplunder/PlunderObjectManager.java
+++ b/Server/src/plugin/activity/pyramidplunder/PlunderObjectManager.java
@@ -1,0 +1,35 @@
+package plugin.activity.pyramidplunder;
+
+import org.crandor.game.node.entity.player.Player;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * Manages what objects a specific player has interacted with in pyramid plunder.
+ * @author ceik
+ */
+
+public class PlunderObjectManager{
+    Player player;
+    public PlunderObjectManager(Player player){
+        this.player = player;
+    }
+    public List<PlunderObject> ObjectList = new ArrayList<PlunderObject>();
+    public boolean resetObjectsFor(Player player){
+        //loadList("plunder.tmp");
+        ListIterator oliter = ObjectList.listIterator();
+        int i = 0;
+        while(oliter.hasNext()){
+            PlunderObject current = (PlunderObject) oliter.next();
+            if(current.playerOpened){
+                current.playerOpened = false;
+            }
+        }
+        return true;
+    }
+
+    public void register(PlunderObject object){
+        ObjectList.add(object);
+    }
+}

--- a/Server/src/plugin/activity/pyramidplunder/PyramidOptionHandler.java
+++ b/Server/src/plugin/activity/pyramidplunder/PyramidOptionHandler.java
@@ -66,6 +66,7 @@ public final class PyramidOptionHandler extends OptionHandler {
 			boolean willBePushed = (RandomFunction.random(10) > 3);
 			if (object.getId() == 16458 || object.getId() == 16459) {
 				ClimbActionHandler.climb(player, ClimbActionHandler.CLIMB_UP, Location.create(3288, 2801, 0));
+				player.getPlunderObjectManager().resetObjectsFor(player);
 				return true;
 			}
 			if (System.currentTimeMillis() - lastEntranceSwitch > 15 * 60 * 1000) {

--- a/Server/src/plugin/dialogue/SimonTempleton.java
+++ b/Server/src/plugin/dialogue/SimonTempleton.java
@@ -47,6 +47,7 @@ public final class SimonTempleton extends DialoguePlugin{
     @Override
     public boolean handle(int interfaceId, int buttonId){
         boolean hasArtefacts = false;
+        boolean hasPyramidTopper = false;
         switch(stage){
             case 0:
                 for(int i = 0; i < ARTIFACTS.length; i++){
@@ -57,7 +58,13 @@ public final class SimonTempleton extends DialoguePlugin{
                         }
                     }
                 }
-                if(hasArtefacts){
+                hasPyramidTopper = player.getInventory().containsItem(new Item(6970));
+                if(hasPyramidTopper){
+                    player("Yes, actually. The top of that pyramid.");
+                    stage = 6;
+                    break;
+                }
+                if(hasArtefacts && !hasPyramidTopper){
                     player("Why, yes I do!");
                     stage = 1;
                     break;
@@ -84,6 +91,36 @@ public final class SimonTempleton extends DialoguePlugin{
             case 5:
                 npc("Bye, mate.");
                 stage = 999;
+                break;
+            case 6:
+                npc("Hmmm, very nice. I'll buy them for 10k each.");
+                stage = 7;
+                break;
+            case 7:
+                interpreter.sendOptions("Select an option.","Sounds good!", "No thanks.");
+                stage = 8;
+                break;
+            case 8:
+                switch(buttonId){
+                    case 1:
+                        for(int j = 0; j < 28; j++){
+                            switch(player.getInventory().getId(j)){
+                                case 6970:
+                                    player.getInventory().remove(new Item(6970),j,true);
+                                    player.getInventory().add(new Item(995, 10000));
+                                    break;
+                            }
+                        }
+                        end();
+                        break;
+                    case 2:
+                        npc("Have it your way.");
+                        stage = 9;
+                        break;
+                }
+                break;
+            case 9:
+                end();
                 break;
             case 10:
                 switch(buttonId){


### PR DESCRIPTION
* Each player node now independently keeps track of what objects they have looted and whether they are able to be looted again
* The objects are reset to unopened when finishing a pyramid run
* Simon Templeton now buys pyramid tops at 10k each.

I wish I could have gotten them to transform to their alternate models for each player independently when opened, but it just isn't possible without the configs for it. Trust me. I tried for hours.
This took me longer than it should have, and I am ashamed of myself.