### PR TITLE
Twinkle twinkle, little star..

### DIFF
--- a/Server/src/org/crandor/game/content/skill/free/gather/GatheringSkillPulse.java
+++ b/Server/src/org/crandor/game/content/skill/free/gather/GatheringSkillPulse.java
@@ -18,12 +18,14 @@ import org.crandor.game.node.entity.player.link.diary.DiaryType;
 import org.crandor.game.node.item.Item;
 import org.crandor.game.node.object.GameObject;
 import org.crandor.game.node.object.ObjectBuilder;
+import org.crandor.game.world.GameWorld;
 import org.crandor.game.world.map.Location;
 import org.crandor.tools.RandomFunction;
 import org.crandor.tools.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -175,8 +177,15 @@ public final class GatheringSkillPulse extends SkillPulse<GameObject> {
 			} else {
 				player.getPacketDispatch().sendMessage("You get some " + ItemDefinition.forId(reward).getName().toLowerCase() + ".");
 			}
-			// Calculate if the player should receive a bonus gem
+			// Calculate if the player should receive a bonus gem or bonus ore or both
 			if (!isMiningEssence && isMining) {
+				//check for bonus ore from shooting star buff
+				if(isMining && (player.getAttribute("SS Mining Bonus", GameWorld.getTicks()) > GameWorld.getTicks())){
+					if(RandomFunction.getRandom(7) == 5) {
+						player.getPacketDispatch().sendMessage("...you manage to mine a second ore thanks to the Star Sprite.");
+						player.getInventory().add(item);
+					}
+				}
 				int chance = 282;
 				boolean altered = false;
 				if (player.getEquipment().getNew(EquipmentContainer.SLOT_RING).getId() == 2572) {

--- a/Server/src/org/crandor/game/node/entity/state/impl/DoubleOrePulse.java
+++ b/Server/src/org/crandor/game/node/entity/state/impl/DoubleOrePulse.java
@@ -1,0 +1,70 @@
+package org.crandor.game.node.entity.state.impl;
+
+import org.crandor.game.node.entity.Entity;
+import org.crandor.game.node.entity.player.Player;
+import org.crandor.game.node.entity.state.StatePulse;
+import org.crandor.game.world.GameWorld;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Pulse for checking remaining time on a shooting star mining bonus and informing the player
+ * @author ceik
+ */
+
+public class DoubleOrePulse extends StatePulse {
+    Player player;
+    Entity entity;
+    int ticks,currentTick;
+    public DoubleOrePulse(Entity entity, int ticks, int currentTick){
+        super(entity,1);
+        this.ticks = ticks;
+        this.currentTick = currentTick;
+        this.player = entity.asPlayer();
+        this.entity = entity;
+    }
+    @Override
+    public boolean isSaveRequired(){return currentTick < ticks;}
+
+    @Override
+    public void save(ByteBuffer buffer){
+        buffer.putInt(ticks);
+        buffer.putInt(currentTick);
+    }
+
+    @Override
+    public StatePulse parse(Entity entity, ByteBuffer buffer){
+        return new DoubleOrePulse(entity, buffer.getInt(), buffer.getInt());
+    }
+
+    @Override
+    public void start() {
+        if (currentTick == GameWorld.getTicks()) {
+            if (entity instanceof Player) {
+                if((int) entity.asPlayer().getAttribute("SS Mining Bonus") > GameWorld.getTicks()){
+                    entity.asPlayer().sendMessage("<col=006600>Your mining bonus is now active!</col>");
+                }
+            }
+        }
+        super.start();
+    }
+
+    @Override
+    public boolean pulse() {
+        int ticksLeft = (int)player.getAttribute("SS Mining Bonus") - GameWorld.getTicks();
+        int minutes = (int)Math.ceil((ticksLeft * .6) / 60);
+        if(ticksLeft % 500 == 0L){
+            player.sendMessage("<col=f0f095>You have " + minutes + " minutes of your mining bonus left</col>");
+        }
+        if(ticksLeft == 0){
+            if((int)ticks <= GameWorld.getTicks()){
+                player.sendMessage("<col=FF0000>Your mining bonus has run out!</col>");
+            }
+        }
+        return !(ticks >= GameWorld.getTicks());
+    }
+    @Override
+    public StatePulse create(Entity entity, Object... args) {
+        return new DoubleOrePulse(entity, entity.asPlayer().getAttribute("SS Mining Bonus"), GameWorld.getTicks());
+    }
+}

--- a/Server/src/plugin/activity/pyramidplunder/PlunderObjectManager.java
+++ b/Server/src/plugin/activity/pyramidplunder/PlunderObjectManager.java
@@ -18,8 +18,9 @@ public class PlunderObjectManager{
     public List<PlunderObject> ObjectList = new ArrayList<PlunderObject>();
     int originalIndex;
     public boolean resetObjectsFor(Player player){
-        //loadList("plunder.tmp");
-        ListIterator oliter = ObjectList.listIterator();
+        //Completely clear the list
+        ObjectList.clear();
+        /*ListIterator oliter = ObjectList.listIterator();
         int i = 0;
         while(oliter.hasNext()){
             PlunderObject current = (PlunderObject) oliter.next();
@@ -29,7 +30,7 @@ public class PlunderObjectManager{
             if(current.snakeCharmed){
                 current.snakeCharmed = false;
             }
-        }
+        }*/
         return true;
     }
 


### PR DESCRIPTION
### Shooting stars
* Shooting stars now award an xp bonus equal to 75 * the mining level of the player for being the first to discover it (same as rs in 2009)
* A news message in chat (similar to the one announcing a star landing) now broadcasts who the first person to discover it is when they discover it. (rs 2009 does this, just not sure if it's exactly in this manner)
* A player can claim the bonus xp even if they do not have the required level to mine the fallen star (same as rs in 2009)
* the turn in limit for stardust is now 200, same as the collection limit.
* When turning in stardust, the player is now correctly awarded with a chance to mine 2 ores at once, in a similar manor to Varrock armor, for the next 15 minutes, same as RS in 2009. This goes away if the player logs out, however.
* Added a new pulse that informs a player of how much bonus mining time they have left.

### Other
* Reduced the max number of blood runes from Ice warriors from 50 to 20, and changed the rarity from UNCOMMON to RARE
* Removed prayer potions from the drop table of Varrock guards.
* Fixed a minor bug with pyramid plunder.